### PR TITLE
mark DNS 100pF capacitors as DNS and 0pF

### DIFF
--- a/pcb/PMW3360-breakout_02 v31_formatted/Assembly/PMW3360-breakout_02 v31.csv
+++ b/pcb/PMW3360-breakout_02 v31_formatted/Assembly/PMW3360-breakout_02 v31.csv
@@ -4,7 +4,7 @@ Qty,Value,Device,Package,Parts,Description,AVAILABILITY,CATEGORY,CHECK_PRICES,CO
 1,0R,R-US_R0402,R0402,R5,"RESISTOR, American symbol",,,,,,,,,,,,,,,34,,,,,,R,,,,
 1,100,R-US_R0402,R0402,R4,"RESISTOR, American symbol",,,,,,,,,,,,,,,34,,,,,,R,,,,
 4,100nF,C_CHIP-0402(1005-METRIC),CAPC1005X60,"C2, C4, C8, C10","Capacitor - Generic",,Capacitor,,,,,,,,,,,,,,,,,,,,,,,
-1,100pF,C-EUC0402K,C0402K,C11,"CAPACITOR, European symbol",,,,,,,,,,,,,,,15,,,,,,C,,,,
+1,0pF,C-EUC0402K,C0402K,C11,"CAPACITOR, European symbol DNS"
 2,10k,R-US_R0402,R0402,"R1, R3","RESISTOR, American symbol",,,,,,,,,,,,,,,34,,,,,,R,,,,
 3,10uF,C_CHIP-0402(1005-METRIC),CAPC1005X60,"C3, C7, C9","Capacitor - Generic",,Capacitor,,,,,,,,,,,,,,,,,,,,,,,
 2,1uF,C_CHIP-0402(1005-METRIC),CAPC1005X60,"C5, C6","Capacitor - Generic",,Capacitor,,,,,,,,,,,,,,,,,,,,,,,

--- a/pcb/teensy-jst_01.4 v10_formatted/Assembly/teensy-jst_01.4 v10.csv
+++ b/pcb/teensy-jst_01.4 v10_formatted/Assembly/teensy-jst_01.4 v10.csv
@@ -8,7 +8,7 @@ Qty,Value,Device,Package,Parts,Description,AVAILABILITY,CATEGORY,CHECK_PRICES,CO
 1,100k,R-US_CHIP-0402(1005-METRIC),RESC1005X40,R23,"Resistor Fixed - ANSI",,Resistor,,,,,,,,,,,,,,,,,,,,,,Fixed,,,,,
 5,100nF,C_CHIP-0402(1005-METRIC),CAPC1005X60,"C9, C14, C15, C16, C17","Capacitor - Generic",,Capacitor,,,,,,,,,,,,,,,,,,,,,,,,,,,
 3,100nF,C_CHIP-0603(1608-METRIC),CAPC1608X85,"C3, C4, C28","Capacitor - Generic",,Capacitor,,,,,,,,,,,,,,,,,,,,,,,,,,,
-10,100pF,C_CHIP-0402(1005-METRIC),CAPC1005X60,"C18, C19, C20, C21, C22, C23, C24, C25, C26, C27","Capacitor - Generic",,Capacitor,,,,,,,,,,,,,,,,,,,,,,,,,,,
+10,0pF,C_CHIP-0402(1005-METRIC),CAPC1005X60,"C18, C19, C20, C21, C22, C23, C24, C25, C26, C27","Capacitor - Generic DNS",,Capacitor,,,,,,,,,,,,,,,,,,,,,,,,,,,
 4,100uF/50V,CPOL-USD,PANASONIC_D,"C1, C2, C12, C13","POLARIZED CAPACITOR, American symbol",,,,,,,,,,,,,,,7,,,,,,,,C,,,,,,
 11,10k,R-US_CHIP-0603(1608-METRIC),RESC1608X60,"R1, R2, R6, R7, R9, R10, R11, R12, R13, R14, R27","Resistor Fixed - ANSI",,Resistor,,,,,,,,,,,,,,,,,,,,,,Fixed,,,,,
 1,10uH,L-USMWSA0503S-100MT,MWSA0503S-100MT,L1,"INDUCTOR, American symbol",,,,,,,,,,,,,,,,,,,,,,,,,,,,,


### PR DESCRIPTION
mark DNS 100pF capacitors as DNS and 0pF so that no one else makes the stupid mistake I did

I built mine using these forms of the spreadsheets (and not the placement ones) because they made sense for someone like me soldering out of those books of SMD tapes (as I usually do) so all the 100R resistors at the same time, just spent the entire afternoon pulling everything apart .....

For the record symptoms are: display doesn't work, some sensors work but when you plug them all in none do

I think there's also an extra cap in the power supply, stuffing that does no harm.